### PR TITLE
add FT_WriteEE missing parameter

### DIFF
--- a/pyftdi/d2xx.py
+++ b/pyftdi/d2xx.py
@@ -995,7 +995,7 @@ class _D2xx(usb.backend.IBackend):
             data[1] = (value >> 8) & 0xFF
             return 0
         elif bmRequestType & 0x80 == 0 and bRequest == Ftdi.SIO_REQ_WRITE_EEPROM:
-            FT_WriteEE(dev_handle.handle, wIndex)
+            FT_WriteEE(dev_handle.handle, wIndex, wValue)
             return 0
         elif bmRequestType & 0x80 == 0 and bRequest == Ftdi.SIO_REQ_ERASE_EEPROM:
             FT_EraseEE(dev_handle.handle)


### PR DESCRIPTION
```
    FT_WriteEE = _ft_function(
        "FT_WriteEE",
        (_IN, FT_HANDLE, "ftHandle"),
        (_IN, DWORD, "dwWordOffset"),
        (_IN, WORD, "wValue"),
    )
```
FT_WriteEE has 3 input parameters defined, but only two are passed in. This causes an exception when writing to the eeprom, 'wValue not set'.